### PR TITLE
Update Notebook with Version 030 #9

### DIFF
--- a/fabric_aw-sdx-with-auth_demo.ipynb
+++ b/fabric_aw-sdx-with-auth_demo.ipynb
@@ -408,7 +408,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sdxlib_version = \"0.29.0\"\n",
+    "sdxlib_version = \"0.30.0\"\n",
     "!pip uninstall -y sdxlib  # Uninstall if installed\n",
     "!pip install --no-cache-dir -i https://test.pypi.org/simple/ sdxlib=={sdxlib_version}"
    ]


### PR DESCRIPTION
Notebook should display all ports, regardless of the number of rows present.