### PR TITLE
fix sdxlib installation URL and comment on test environment

### DIFF
--- a/knit10-sdx-layer2.ipynb
+++ b/knit10-sdx-layer2.ipynb
@@ -277,8 +277,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sdxlib_version = \"0.33.0\"\n",
-    "!pip install --no-cache-dir -i https://test.pypi.org/simple/ sdxlib=={sdxlib_version}"
+    "!pip install --no-cache-dir https://github.com/atlanticwave-sdx/sdx-lib/archive/refs/heads/release/0.35.zip"
    ]
   },
   {
@@ -362,8 +361,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Test Environment URL\n",
-    "sdx_url = \"https://sdxapi.atlanticwave-sdx.ai/test\""
+    "# Test Environment URL -- uncomment the following line to use the test environment\n",
+    "#sdx_url = \"https://sdxapi.atlanticwave-sdx.ai/test\""
    ]
   },
   {


### PR DESCRIPTION
This PR fixes the installation URL pointing to GitHub repo directly to benefit from future improvements easily.

Heads-up: this PR should be merged only after PR https://github.com/atlanticwave-sdx/sdx-lib/pull/76