### PR TITLE
vlan availability #18

### DIFF
--- a/sdxclient/client.py
+++ b/sdxclient/client.py
@@ -75,6 +75,18 @@ class SDXClient:
         }
 
     # ---------- Listings (pass-through) ----------
+    def get_topology(self) -> Dict[str, Any]:
+        """Fetch raw topology via the API route using the client's Bearer token."""
+        return _http_request(
+            self.session,
+            self.base_url,
+            "GET",
+            "/topology",
+            accept="application/json",
+            timeout=self.timeout,
+            expect_json=True,
+        )
+
     def get_available_ports(
         self,
         *,
@@ -190,6 +202,24 @@ class SDXClient:
             self._second_endpoint = endpoint_data
 
         return {"status_code": 200, "data": endpoint_data, "error": None}
+
+    # ---------- VLAN availability (pass-throughs) ----------
+    def get_all_vlans_available(self) -> Dict[str, Any]:
+        """Bulk VLAN availability for all ports."""
+        return _http_request(
+            self.session, self.base_url, "GET", "/available_vlans",
+            params={"format": "json"}, accept="application/json",
+            timeout=self.timeout, expect_json=True,
+        )
+
+    def get_port_vlans_available(self, port_id: str) -> Dict[str, Any]:
+        """VLAN availability for a single port."""
+        params: Dict[str, str] = {"format": "json", "port_id": str(port_id)}
+        return _http_request(
+            self.session, self.base_url, "GET", "/available_vlans",
+            params=params, accept="application/json",
+            timeout=self.timeout, expect_json=True,
+        )
 
     # ---------- Preview & create ----------
     def preview_l2vpn_payload(self, *, name: str, notifications: str) -> Dict[str, Any]:


### PR DESCRIPTION
Takes the topology data or a port_id.

Looks at the services → l2vpn_ptp → vlan_range field.

Normalizes ranges like ["1-4094"] or [[1, 4094]] into a list of integers or ranges.

This becomes the basis for a new API call (/available_vlans or /ports/<id>/vlans) once the SDX Controller exposes it.

For now, it would be used internally by:

get_available_ports(..., include_vlans=True) → attach VLAN availability.

set_endpoint(..., prefer_untagged=True) → decide on VLAN selection.

Display helpers → so the user sees VLANs in the listing before trying to build an L2VPN.