### PR TITLE
fix-artifact-uploaddownload-paths-in-publishyml #30

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,24 +2,21 @@ name: Build & Publish (TestPyPI → PyPI)
 
 on:
   push:
-    branches: ["main"]              # publish to TestPyPI on merge to main
-    tags:
-      - "v*.*.*"                    # publish to PyPI on version tags
+    branches: ["main"]                # publish to TestPyPI on merge to main
+    tags: ["v*.*.*"]                  # publish to PyPI on version tags
   pull_request:
-    branches: ["main"]              # build-only on PRs targeting main
-  workflow_dispatch:                 # manual trigger from Actions tab
+    branches: ["main"]                # build-only on PRs
+  workflow_dispatch:
     inputs:
       target:
         description: "Choose where to publish"
         required: true
         default: "testpypi"
         type: choice
-        options:
-          - testpypi
-          - pypi
+        options: [testpypi, pypi]
 
 permissions:
-  id-token: write                   # REQUIRED for OIDC Trusted Publishing
+  id-token: write                     # REQUIRED for OIDC Trusted Publishing
   contents: read
 
 env:
@@ -27,9 +24,7 @@ env:
   PROD_SDX_BASE_URL: https://sdxapi.atlanticwave-sdx.ai
 
 jobs:
-  # Build on PRs only (no publishing)
   pr-build:
-    name: Build on pull_request (no publish)
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     defaults:
@@ -37,18 +32,11 @@ jobs:
         working-directory: sdx-client
     steps:
       - uses: actions/checkout@v4
-
       - uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
+        with: { python-version: "3.11" }
+      - run: python -m pip install --upgrade build
+      - run: python -m build
 
-      - name: Install build tool
-        run: python -m pip install --upgrade build
-
-      - name: Build sdist and wheel
-        run: python -m build
-
-  # Build artifacts for push/tag/manual (publishing paths)
   build:
     name: Build package artifacts
     if: github.event_name != 'pull_request'
@@ -58,28 +46,19 @@ jobs:
         working-directory: sdx-client
     steps:
       - uses: actions/checkout@v4
-
       - uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
-      - name: Install build tool
-        run: python -m pip install --upgrade build
-
-      - name: Build sdist and wheel
-        run: python -m build
-
+        with: { python-version: "3.11" }
+      - run: python -m pip install --upgrade build
+      - run: python -m build
       - name: Upload dist artifacts
         uses: actions/upload-artifact@v4
         with:
           name: dist
-          path: dist/*
+          path: sdx-client/dist/*           # ← repo-root path
+          if-no-files-found: error
 
   publish-testpypi:
     name: Publish to TestPyPI
-    # Runs on:
-    # - push to main (merge)
-    # - OR manual dispatch with target == testpypi
     if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || (github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'testpypi'))
     needs: build
     runs-on: ubuntu-latest
@@ -87,12 +66,13 @@ jobs:
       run:
         working-directory: sdx-client
     steps:
+      - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:
           name: dist
-          path: dist
-
-      # Guard: require pre-release (rc) for TestPyPI
+          path: sdx-client/dist             # ← repo-root path
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.11" }
       - name: Ensure pre-release version
         run: |
           python - <<'PY'
@@ -102,21 +82,16 @@ jobs:
               print(f"ERROR: TestPyPI publishes must use pre-release (found {ver})")
               sys.exit(1)
           PY
-
-      - name: Set test base URL for this job
-        run: echo "SDX_BASE_URL=${{ env.TEST_SDX_BASE_URL }}" >> $GITHUB_ENV
-
+      - run: echo "SDX_BASE_URL=${{ env.TEST_SDX_BASE_URL }}" >> $GITHUB_ENV
       - name: Publish to TestPyPI (OIDC Trusted Publishing)
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
           skip-existing: true
+          packages-dir: sdx-client/dist     # ← repo-root path
 
   publish-pypi:
     name: Publish to PyPI
-    # Runs on:
-    # - tag push (vX.Y.Z)
-    # - OR manual dispatch with target == pypi
     if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'pypi'))
     needs: build
     runs-on: ubuntu-latest
@@ -124,12 +99,13 @@ jobs:
       run:
         working-directory: sdx-client
     steps:
+      - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:
           name: dist
-          path: dist
-
-      # Guard: require final (non-rc) for PyPI
+          path: sdx-client/dist             # ← repo-root path
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.11" }
       - name: Ensure final version
         run: |
           python - <<'PY'
@@ -139,12 +115,10 @@ jobs:
               print(f"ERROR: PyPI publishes must be final (found {ver})")
               sys.exit(1)
           PY
-
-      - name: Set prod base URL for this job
-        run: echo "SDX_BASE_URL=${{ env.PROD_SDX_BASE_URL }}" >> $GITHUB_ENV
-
+      - run: echo "SDX_BASE_URL=${{ env.PROD_SDX_BASE_URL }}" >> $GITHUB_ENV
       - name: Publish to PyPI (OIDC Trusted Publishing)
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           skip-existing: true
+          packages-dir: sdx-client/dist     # ← repo-root path
 


### PR DESCRIPTION
In the build job, upload artifacts from path: dist/* (relative to sdx-client/).

In the publish jobs, download artifacts into path: dist (relative to sdx-client/).

Ensure pypa/gh-action-pypi-publish reads from dist/ inside sdx-client.

This will keep the workflow consistent, prevent double-prefixed sdx-client/dist/dist, and ensure publishing jobs can always find the wheel and sdist files generated by the build step.