### PR TITLE
Default SDX client config to Production endpoint #34

### DIFF
--- a/sdx-client/README.md
+++ b/sdx-client/README.md
@@ -236,13 +236,7 @@ pip install --index-url https://test.pypi.org/simple/ \
 
 - sdxclient reads the base URL from the environment:
 
-## Test (default if unset in config.py)
-export SDX_BASE_URL=http://190.103.184.194
-
-## Production
-export SDX_BASE_URL=https://sdxapi.atlanticwave-sdx.ai
-
-- If SDX_BASE_URL isn’t set, the package falls back to the default defined in sdxclient/config.py.
+- If SDX_BASE_URL isn’t set, the package falls back to production.
 
 ## Releasing (maintainers)
 

--- a/sdx-client/sdxclient/config.py
+++ b/sdx-client/sdxclient/config.py
@@ -4,5 +4,5 @@ import os
 # BASE_URL = "https://sdxapi.atlanticwave-sdx.ai"
 BASE_URL = os.getenv(
     "SDX_BASE_URL",  # environment variable if defined
-    "http://190.103.184.194"  # default (test)
+    "https://sdxapi.atlanticwave-sdx.ai"  # default (prod)
 )


### PR DESCRIPTION
flip this:

Default → Production (https://sdxapi.atlanticwave-sdx.ai)

Optional override → Developers can still set SDX_BASE_URL to point to a test endpoint if needed.