### PR TITLE
38 stop sdxclient hardcoding the pypi version and make releases tag driven

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,29 +2,36 @@ name: Build & Publish (TestPyPI → PyPI)
 
 on:
   push:
-    branches: ["main"]                # publish to TestPyPI on merge to main
-    tags: ["v*.*.*"]                  # publish to PyPI on version tags
+    branches: ["main"]              # publish to TestPyPI on merge to main
+    tags:
+      - "v*.*.*"                    # publish to PyPI on version tags
   pull_request:
-    branches: ["main"]                # build-only on PRs
-  workflow_dispatch:
+    branches: ["main"]              # build-only on PRs targeting main
+  workflow_dispatch:                 # manual trigger from Actions tab
     inputs:
       target:
         description: "Choose where to publish"
         required: true
         default: "testpypi"
         type: choice
-        options: [testpypi, pypi]
+        options:
+          - testpypi
+          - pypi
 
 permissions:
-  id-token: write                     # REQUIRED for OIDC Trusted Publishing
+  id-token: write                   # REQUIRED for OIDC Trusted Publishing
   contents: read
 
 env:
+  SDX_BASE_URL: https://sdxapi.atlanticwave-sdx.ai
   TEST_SDX_BASE_URL: https://190.103.184.194
-  PROD_SDX_BASE_URL: https://sdxapi.atlanticwave-sdx.ai
 
 jobs:
+  # ----------------------------------------------------
+  # Build on pull requests only (no publish)
+  # ----------------------------------------------------
   pr-build:
+    name: Build on pull_request (no publish)
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     defaults:
@@ -32,11 +39,23 @@ jobs:
         working-directory: sdx-client
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with: { python-version: "3.11" }
-      - run: python -m pip install --upgrade build
-      - run: python -m build
+        with:
+          fetch-depth: 0          # full history for setuptools_scm
+          fetch-tags: true
 
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install build tool
+        run: python -m pip install --upgrade build
+
+      - name: Build sdist and wheel
+        run: python -m build
+
+  # ----------------------------------------------------
+  # Build artifacts for push/tag/manual
+  # ----------------------------------------------------
   build:
     name: Build package artifacts
     if: github.event_name != 'pull_request'
@@ -46,17 +65,29 @@ jobs:
         working-directory: sdx-client
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0          # full history for setuptools_scm
+          fetch-tags: true
+
       - uses: actions/setup-python@v5
-        with: { python-version: "3.11" }
-      - run: python -m pip install --upgrade build
-      - run: python -m build
+        with:
+          python-version: "3.11"
+
+      - name: Install build tool
+        run: python -m pip install --upgrade build
+
+      - name: Build sdist and wheel
+        run: python -m build
+
       - name: Upload dist artifacts
         uses: actions/upload-artifact@v4
         with:
           name: dist
-          path: sdx-client/dist/*           # ← repo-root path
-          if-no-files-found: error
+          path: dist/*
 
+  # ----------------------------------------------------
+  # Publish to TestPyPI
+  # ----------------------------------------------------
   publish-testpypi:
     name: Publish to TestPyPI
     if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || (github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'testpypi'))
@@ -65,31 +96,23 @@ jobs:
     defaults:
       run:
         working-directory: sdx-client
+    env:
+      SDX_BASE_URL: ${{ env.TEST_SDX_BASE_URL }}   # runtime override for test
     steps:
-      - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:
           name: dist
-          path: sdx-client/dist             # ← repo-root path
-      - uses: actions/setup-python@v5
-        with: { python-version: "3.11" }
-      - name: Ensure pre-release version
-        run: |
-          python - <<'PY'
-          import sys, pathlib, tomllib
-          ver = tomllib.loads(pathlib.Path("pyproject.toml").read_text())["project"]["version"]
-          if "rc" not in ver:
-              print(f"ERROR: TestPyPI publishes must use pre-release (found {ver})")
-              sys.exit(1)
-          PY
-      - run: echo "SDX_BASE_URL=${{ env.TEST_SDX_BASE_URL }}" >> $GITHUB_ENV
+          path: dist
+
       - name: Publish to TestPyPI (OIDC Trusted Publishing)
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
           skip-existing: true
-          packages-dir: sdx-client/dist     # ← repo-root path
 
+  # ----------------------------------------------------
+  # Publish to PyPI
+  # ----------------------------------------------------
   publish-pypi:
     name: Publish to PyPI
     if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'pypi'))
@@ -99,26 +122,13 @@ jobs:
       run:
         working-directory: sdx-client
     steps:
-      - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:
           name: dist
-          path: sdx-client/dist             # ← repo-root path
-      - uses: actions/setup-python@v5
-        with: { python-version: "3.11" }
-      - name: Ensure final version
-        run: |
-          python - <<'PY'
-          import sys, pathlib, tomllib
-          ver = tomllib.loads(pathlib.Path("pyproject.toml").read_text())["project"]["version"]
-          if "rc" in ver:
-              print(f"ERROR: PyPI publishes must be final (found {ver})")
-              sys.exit(1)
-          PY
-      - run: echo "SDX_BASE_URL=${{ env.PROD_SDX_BASE_URL }}" >> $GITHUB_ENV
+          path: dist
+
       - name: Publish to PyPI (OIDC Trusted Publishing)
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           skip-existing: true
-          packages-dir: sdx-client/dist     # ← repo-root path
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,34 +2,28 @@ name: Build & Publish (TestPyPI → PyPI)
 
 on:
   push:
-    branches: ["main"]              # publish to TestPyPI on merge to main
-    tags:
-      - "v*.*.*"                    # publish to PyPI on version tags
+    branches: ["main"]
+    tags: ["v*.*.*"]
   pull_request:
-    branches: ["main"]              # build-only on PRs targeting main
-  workflow_dispatch:                 # manual trigger from Actions tab
+    branches: ["main"]
+  workflow_dispatch:
     inputs:
       target:
         description: "Choose where to publish"
         required: true
         default: "testpypi"
         type: choice
-        options:
-          - testpypi
-          - pypi
+        options: [testpypi, pypi]
 
 permissions:
-  id-token: write                   # REQUIRED for OIDC Trusted Publishing
+  id-token: write
   contents: read
 
 env:
-  SDX_BASE_URL: https://sdxapi.atlanticwave-sdx.ai
-  TEST_SDX_BASE_URL: https://190.103.184.194
+  SDX_BASE_URL: https://sdxapi.atlanticwave-sdx.ai      # prod default
+  TEST_SDX_BASE_URL: https://190.103.184.194            # test default
 
 jobs:
-  # ----------------------------------------------------
-  # Build on pull requests only (no publish)
-  # ----------------------------------------------------
   pr-build:
     name: Build on pull_request (no publish)
     if: github.event_name == 'pull_request'
@@ -40,22 +34,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0          # full history for setuptools_scm
+          fetch-depth: 0          # needed for setuptools_scm
           fetch-tags: true
-
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-
       - name: Install build tool
         run: python -m pip install --upgrade build
-
       - name: Build sdist and wheel
         run: python -m build
 
-  # ----------------------------------------------------
-  # Build artifacts for push/tag/manual
-  # ----------------------------------------------------
   build:
     name: Build package artifacts
     if: github.event_name != 'pull_request'
@@ -66,28 +54,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0          # full history for setuptools_scm
+          fetch-depth: 0
           fetch-tags: true
-
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-
       - name: Install build tool
         run: python -m pip install --upgrade build
-
       - name: Build sdist and wheel
         run: python -m build
-
       - name: Upload dist artifacts
         uses: actions/upload-artifact@v4
         with:
           name: dist
           path: dist/*
 
-  # ----------------------------------------------------
-  # Publish to TestPyPI
-  # ----------------------------------------------------
   publish-testpypi:
     name: Publish to TestPyPI
     if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || (github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'testpypi'))
@@ -96,13 +77,32 @@ jobs:
     defaults:
       run:
         working-directory: sdx-client
-    env:
-      SDX_BASE_URL: ${{ env.TEST_SDX_BASE_URL }}   # runtime override for test
     steps:
       - uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist
+
+      # need repo + tags for git describe guard
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      # Dynamically set runtime base URL for test
+      - name: Set SDX_BASE_URL for TestPyPI
+        run: echo "SDX_BASE_URL=${TEST_SDX_BASE_URL}" >> "$GITHUB_ENV"
+
+      # Guard: must NOT be a clean release tag
+      - name: Ensure NOT a final release tag
+        run: |
+          python - <<'PY'
+          import subprocess, re, sys
+          ref = subprocess.check_output(["git","describe","--tags","--dirty","--always"], text=True).strip()
+          if re.fullmatch(r"v\d+\.\d+\.\d+", ref):
+              sys.exit(f"Ref {ref} is a final tag; TestPyPI expects a dev/pre build.")
+          print(f"OK: {ref} is not a final tag")
+          PY
 
       - name: Publish to TestPyPI (OIDC Trusted Publishing)
         uses: pypa/gh-action-pypi-publish@release/v1
@@ -110,9 +110,6 @@ jobs:
           repository-url: https://test.pypi.org/legacy/
           skip-existing: true
 
-  # ----------------------------------------------------
-  # Publish to PyPI
-  # ----------------------------------------------------
   publish-pypi:
     name: Publish to PyPI
     if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'pypi'))
@@ -126,6 +123,23 @@ jobs:
         with:
           name: dist
           path: dist
+
+      # need repo + tags for git describe guard
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      # Guard: must BE a clean release tag
+      - name: Ensure final release tag (vX.Y.Z)
+        run: |
+          python - <<'PY'
+          import subprocess, re, sys
+          ref = subprocess.check_output(["git","describe","--tags","--dirty","--always"], text=True).strip()
+          if not re.fullmatch(r"v\d+\.\d+\.\d+", ref):
+              sys.exit(f"Ref {ref} is not a clean final tag vX.Y.Z (got {ref}).")
+          print(f"OK: {ref} is a final tag")
+          PY
 
       - name: Publish to PyPI (OIDC Trusted Publishing)
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/sdx-client/README.md
+++ b/sdx-client/README.md
@@ -21,7 +21,7 @@ A thin Python client that wraps the SDX HTTP routes, stages L2VPN payload metada
 
 ```python
 from sdxclient import SDXClient
-client = SDXClient(timeout=6.0)            # tries FABRIC token
+client = SDXClient()            # tries FABRIC token
 ```
 
 ## Return Shape (always)
@@ -263,83 +263,88 @@ pip install --index-url https://test.pypi.org/simple/ \
 
 ## Install for testing:
 
+```bash
 pip install --index-url https://test.pypi.org/simple/ \
             --extra-index-url https://pypi.org/simple \
             sdxclient==X.Y.ZrcN
+```
 
-## Production release (PyPI)
+# Releasing and Publishing
 
-### Bump version to a final:
-
-- version = "X.Y.Z"
-
-
-### Tag and push the tag:
-
-- git tag vX.Y.Z
-- git push origin vX.Y.Z
-- (Or run the workflow manually with target: pypi.)
-
-## Install from PyPI:
-
-pip install sdxclient==X.Y.Z
-
-## Rules the workflow enforces
-
-- TestPyPI requires version to contain rc.
-- PyPI requires version without rc.
-- Publishing uses OIDC (no API tokens).
-- Manual run (optional)
-
-## From GitHub → Actions → “Build & Publish (TestPyPI → PyPI)” → Run workflow:
-
-- target: testpypi (expects rc in version)
-- target: pypi (expects final version)
-- Pick the branch that contains your version bump.
-
-# Releases & Publishing
-
-- This project is published to both TestPyPI (pre-releases) and PyPI (final releases).
-- Publishing is automated through GitHub Actions.
+### This project uses setuptools_scm for automatic versioning from Git tags.
+### GitHub Actions handles all publishing to TestPyPI and PyPI using OIDC Trusted Publishing — no API tokens needed.
 
 ## Versioning Rules
 
-- Every release must use a new unique version in sdx-client/pyproject.toml.
-- Pre-releases (for testing) use the rc suffix, e.g.:
+- Do not edit the version manually in pyproject.toml.
+- The version is derived automatically from your latest Git tag.
+- Pre-releases (for testing) use release candidate tags:
 
-version = "0.10.1rc1"
+```bash
+git tag v0.10.1rc1
+git push origin v0.10.1rc1
+```
 
-## Final production releases use only numbers:
+### → publishes to TestPyPI with version 0.10.1rc1.
 
-version = "0.10.1"
+- Final production releases use numeric tags only:
 
-## Release Flow
-
-- Update version in pyproject.toml.
-- Example: bump from 0.10.0 → 0.10.1rc1 for TestPyPI, or 0.10.1 for PyPI.
-
-git add sdx-client/pyproject.toml
-git commit -m "Bump version to 0.10.1rc1"
-git push
-
-
-## Trigger TestPyPI publish (pre-release):
-
-- Merge to main, or
-- Manually run the GitHub Action with target=testpypi.
-
-## Trigger PyPI publish (final release):
-
-- Ensure pyproject.toml has a final version (no rc).
-
-## Tag the commit and push the tag:
-
-git tag v0.10.1
+```bash
+git tag -a v0.10.1 -m "Release 0.10.1"
 git push origin v0.10.1
+```
 
+### → publishes to PyPI with version 0.10.1.
 
-## This will run the publish job to PyPI automatically.
+# Test Builds (TestPyPI)
 
-## Switching Between Test & Production
+- Trigger:
 
-## The client uses an environment variable to choose which API endpoint to talk to Production (default if not set)
+- Merge or push to the main branch
+- Manual workflow run with target=testpypi
+
+- Version format:
+
+- 0.10.x.devN+gHASH (auto-generated dev build)
+- or 0.10.1rc1 (pre-release tag)
+
+- Install from TestPyPI:
+
+```bash
+pip install -i https://test.pypi.org/simple/ sdxclient
+```
+
+# Production Releases (PyPI)
+
+- Trigger: push an annotated tag vX.Y.Z
+
+- Version format: clean X.Y.Z (no rc, no dev)
+
+- Install from PyPI:
+
+```bash
+pip install sdxclient==X.Y.Z
+```
+
+# Manual Publishing (optional)
+
+## run the workflow manually from GitHub:
+
+### Actions → “Build & Publish (TestPyPI → PyPI)” → “Run workflow”
+
+## Pick:
+
+- target: testpypi → expects pre-release or dev version
+- target: pypi → expects final version
+- Choose the branch or tag that contains your release commit.
+
+# Rules Enforced by the Workflow
+
+- TestPyPI: only accepts pre-release or dev versions (rc, devN, etc.).
+- PyPI: only accepts clean versions (no suffix).
+- No API tokens: OIDC Trusted Publishing handles authentication.
+- Same wheel: one build artifact published to both indexes.
+- Runtime URLs:
+
+- Test: SDX_BASE_URL=https://190.103.184.194
+- Prod: SDX_BASE_URL=https://sdxapi.atlanticwave-sdx.ai

--- a/sdx-client/pyproject.toml
+++ b/sdx-client/pyproject.toml
@@ -1,28 +1,23 @@
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=61", "setuptools_scm>=8", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "sdxclient"
-version = "0.10.1"
-# version = "0.10.1rc1"
+dynamic = ["version"]                # <-- version comes from git
 description = "A Python client library for interacting with the AtlanticWave-SDX L2VPN API"
 readme = "README.md"
-authors = [
-  { name = "FIU", email = "lmarinve@gmail.com" }
-]
+authors = [{ name = "FIU", email = "lmarinve@gmail.com" }]
 license = { text = "MIT" }
 requires-python = ">=3.9"
 
-# Core runtime deps only—keep base install light.
 dependencies = [
-  "requests>=2.31.0",
-  "pandas>=2.0.0",
-  "PyJWT>=2.6.0"
+  "requests>=2.32.5",
+  "pandas==2.3.3",
+  "PyJWT==2.9.0"
 ]
 
 [project.optional-dependencies]
-# Install with: pip install "sdxclient[fabric]"
 fabric = ["fabrictestbed-extensions>=1.5.0"]
 
 [tool.setuptools.packages.find]
@@ -31,6 +26,13 @@ include = ["sdxclient*"]
 
 [tool.setuptools]
 include-package-data = true
+
+[tool.setuptools_scm]
+# Optional knobs; safe defaults
+version_scheme = "guess-next-dev"
+local_scheme = "node-and-date"
+# If you ever build from an sdist without .git, write the resolved version into the package:
+write_to = "sdxclient/_version.py"
 
 [project.urls]
 Homepage = "https://github.com/atlanticwave-sdx/sdx-fabric"


### PR DESCRIPTION
Added dynamic environment export (SDX_BASE_URL) using $GITHUB_ENV for TestPyPI jobs.

Ensures setuptools_scm has full tag history by checking out with fetch-depth: 0 and fetch-tags: true.

Keeps separate publish paths:

TestPyPI → when pushing to main or running manually with target=testpypi.

PyPI → when pushing annotated tags (vX.Y.Z) or running manually with target=pypi.

Restores tag guard logic with repo checkout, ensuring correct tagging conventions.

Maintains OIDC Trusted Publishing (no API tokens required).